### PR TITLE
Fix "expect.errWith()" expecting filename and line number prepended to the message

### DIFF
--- a/lua/gluatest/expectations/positive.lua
+++ b/lua/gluatest/expectations/positive.lua
@@ -105,7 +105,7 @@ return function( subject, ... )
         if success == true then
             i.expected( "to error with '%s'", comparison )
         else
-            if string.StartWith( err, "lua/" ) then
+            if string.StartWith( err, "lua/" ) or string.StartWith( err, "addons/" ) then
                 err = string.Split( err, ": " )[2]
             end
 


### PR DESCRIPTION
Solves situations like this:
```
Expected function: 0x7f56cc5ec010 to error with 'Expected a string.', got 'addons/project/lua/my/code.lua:35: Expected a string.'
```