### PR TITLE
Ignore expectations in late async tests

### DIFF
--- a/lua/gluatest/runner/runner.lua
+++ b/lua/gluatest/runner/runner.lua
@@ -156,6 +156,8 @@ return function( allTestGroups )
             -- This will only be called once, even though many
             -- expectations may fail.
             local onFailedExpectation = function( errInfo )
+                if callbacks[case.id] ~= nil then return end
+
                 addResult( false, case, errInfo )
                 expectationFailure = true
             end


### PR DESCRIPTION
This should fix the issue presented in #23
