### PR TITLE
Fix negative errWith, fix error parsing in both

### DIFF
--- a/lua/gluatest/expectations/negative.lua
+++ b/lua/gluatest/expectations/negative.lua
@@ -3,7 +3,9 @@ local IsValid = IsValid
 local string_format = string.format
 
 -- Inverse checks
-return function( subject )
+return function( subject, ... )
+    local args = { ... }
+
     local expectations = {
         expected = function( suffix, ... )
             local fmt = "Expectation Failed: Expected %s " .. suffix
@@ -103,12 +105,17 @@ return function( subject )
     end
 
     function expectations.errWith( comparison )
-        local success, err = pcall( subject )
+        local success, err = pcall( subject, unpack( args ) )
 
         if success == true then
             i.expected( "to error" )
         else
-            err = string.Split( err, ": " )[2]
+            if string.StartWith( err, "lua/" ) or string.StartWith( err, "addons/" ) then
+                local _, endOfPath = string.find( err, ":%d+: ", 1 )
+                assert( endOfPath, "Could not find end of path in error message: " .. err )
+
+                err = string.sub( err, endOfPath + 1 )
+            end
 
             if err == comparison then
                 i.expected( "to not error with '%s'", comparison )

--- a/lua/gluatest/expectations/negative.lua
+++ b/lua/gluatest/expectations/negative.lua
@@ -89,7 +89,7 @@ return function( subject, ... )
     end
 
     function expectations.succeed()
-        local success = pcall( subject )
+        local success = pcall( subject, unpack( args ) )
 
         if success ~= false then
             i.expected( "to not succeed" )
@@ -97,7 +97,7 @@ return function( subject, ... )
     end
 
     function expectations.err()
-        local success = pcall( subject )
+        local success = pcall( subject, unpack( args ) )
 
         if success ~= true then
             i.expected( "to not error" )

--- a/lua/gluatest/expectations/positive.lua
+++ b/lua/gluatest/expectations/positive.lua
@@ -106,7 +106,10 @@ return function( subject, ... )
             i.expected( "to error with '%s'", comparison )
         else
             if string.StartWith( err, "lua/" ) or string.StartWith( err, "addons/" ) then
-                err = string.Split( err, ": " )[2]
+                local _, endOfPath = string.find( err, ":%d+: ", 1 )
+                assert( endOfPath, "Could not find end of path in error message: " .. err )
+
+                err = string.sub( err, endOfPath + 1 )
             end
 
             if err ~= comparison then


### PR DESCRIPTION
The negative expectations weren't even taking in any args, so I fixed that up.

Then I noticed that the error parsing itself didn't work if the error message had a colon in it, so I believe I fixed that too.