### PR TITLE
Fix tests that try to stub the hook table

### DIFF
--- a/lua/gluatest/runner/helpers.lua
+++ b/lua/gluatest/runner/helpers.lua
@@ -23,7 +23,21 @@ local makeHookTable = function()
         end
     end
 
-    return table.Inherit( { Add = hook_Add }, hook ), cleanup
+    local newHookTable = setmetatable( {}, {
+        __index = function( _, key )
+            if key == "Add" then
+                return hook_Add
+            end
+
+            return rawget( _G.hook, key )
+        end,
+
+        __newindex = function( _, key, value )
+            rawset( _G.hook, key, value )
+        end
+    } )
+
+    return newHookTable, cleanup
 end
 
 local function makeTimerTable()
@@ -99,7 +113,7 @@ local function makeTestEnv()
         {
             __index = function( _, idx )
                 return testEnv[idx] or _G[idx]
-            end
+            end,
         }
     ), cleanup
 end

--- a/lua/gluatest/runner/helpers.lua
+++ b/lua/gluatest/runner/helpers.lua
@@ -12,13 +12,20 @@ local makeHookTable = function()
         if not trackedHooks[event] then trackedHooks[event] = {} end
         table.insert( trackedHooks[event], name )
 
-        return hook.Add( event, name, func, ... )
+        if not isfunction( func ) and func.IsStub then
+            local givenStub = func
+            func = function( ... )
+                givenStub( ... )
+            end
+        end
+
+        return _G.hook.Add( event, name, func, ... )
     end
 
     local function cleanup()
         for event, names in pairs( trackedHooks ) do
             for _, name in ipairs( names ) do
-                hook.Remove( event, name )
+                _G.hook.Remove( event, name )
             end
         end
     end

--- a/lua/gluatest/stubs/stubMaker.lua
+++ b/lua/gluatest/stubs/stubMaker.lua
@@ -14,13 +14,15 @@ return function()
         local original = tbl and tbl[key]
 
         local stubTbl = {
+            IsStub = true,
             callCount = 0,
             callHistory = {},
             restored = false,
             Restore = function( self )
                 if self.restored then return end
-
                 self.restored = true
+
+                if not tbl then return end
                 tbl[key] = original
             end,
         }

--- a/lua/gluatest/stubs/stubMaker.lua
+++ b/lua/gluatest/stubs/stubMaker.lua
@@ -18,7 +18,6 @@ return function()
             callHistory = {},
             restored = false,
             Restore = function( self )
-                if not original then return end
                 if self.restored then return end
 
                 self.restored = true


### PR DESCRIPTION
Currently, if you do:

```lua
-- code
myProject.CallHook( name, ... )
    hook.Run( name, ... )
end

-- test
func = function()
    local runStub = stub( hook, "Run" )
    myProject.CallHook( "test" )

    expect( runStub ).to.haveBeenCalled()
end
```

This would fail, because the `stub` library is trying to stub `Run` on the _fake_ `hook` library that we set in the test environment.

The fix presented here would give the `hook` (and probably `timer`?) environment tables a metatable that would pass-through SET operations to the real `hook` (and `timer`) tables, letting stubs actually stub the real functions.

I didn't notice any side effects from doing this, but I'm going to play with it a bit more before merging.

e: One obvious issue here is that if you stub out any of the real hook methods, it'll fuck up anything in the entire lua environment that wants to use them... including GLuaTest..
If you put an expectation (or other kind of erroring code) in the stub, GLuaTest breaks because it can't find the debug info to report the error properly :/