### PR TITLE
Update set-output usage

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -67,7 +67,7 @@ jobs:
           git fetch --quiet --tags
           latest="$(git describe --tags `git rev-list --tags --max-count=1`)"
           echo "Latest Tag: $latest"
-          echo "::set-output name=LATEST_TAG::$latest"
+          echo "{LATEST_TAG}=$latest" >> $GITHUB_STATE
 
           cd $GITHUB_WORKSPACE
 

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -67,7 +67,7 @@ jobs:
           git fetch --quiet --tags
           latest="$(git describe --tags `git rev-list --tags --max-count=1`)"
           echo "Latest Tag: $latest"
-          echo "{LATEST_TAG}=$latest" >> $GITHUB_STATE
+          echo "LATEST_TAG=$latest" >> $GITHUB_OUTPUT
 
           cd $GITHUB_WORKSPACE
 

--- a/lua/gluatest/runner/logger.lua
+++ b/lua/gluatest/runner/logger.lua
@@ -149,7 +149,7 @@ function ResultLogger.LogFileStart( testGroup )
     local identifier = project .. "/" .. ( groupName or fileName )
 
     MsgC( "\n" )
-    ResultLogger.prefixLog( colors.blue, "=== Running ", identifier , "... ===", "\n" )
+    ResultLogger.prefixLog( colors.blue, "=== Running ", identifier, "... ===", "\n" )
 end
 
 function ResultLogger.LogTestResult( result )


### PR DESCRIPTION
ref: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/