### PR TITLE
Add "was" expectation prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,25 +442,29 @@ There are a number of different expectations you can use.
 #### Expectations
 | Expectation          | Description                                           | Example                                                         |
 |----------------------|-------------------------------------------------------|-----------------------------------------------------------------|
-| **`equal`**/**`eq`** | Basic `==` equality check                             | `expect( a ).to.equal( b )`                                     |
+| **`equal`**/**`eq`**     | Basic `==` equality check                             | `expect( a ).to.equal( b )`                                     |
 | **`beLessThan`**     | Basic `<` comparison                                  | `expect( 5 ).to.beLessThan( 6 )`                                |
 | **`beGreaterThan`**  | Basic `>` comparison                                  | `expect( 10 ).to.beGreaterThan( 1 )`                            |
 | **`beTrue`**         | Expects the subject to literally be `true`            | `expect( Entity( 1 ):IsPlayer() ).to.beTrue()`                  |
 | **`beFalse`**        | Expects the subject to literally be `false`           | `expect( istable( "test" ) ).to.beFalse()`                      |
 | **`beValid`**        | Expects `IsValid( value )` to return `true`           | `expect( ply ).to.beValid()`                                    |
-| **`beInvalid`**      | Expects `IsValid( value )` to return `false`          | `expect( nil ).to.beInvalid()`                                   |
+| **`beInvalid`**      | Expects `IsValid( value )` to return `false`          | `expect( nil ).to.beInvalid()`                                  |
 | **`beNil`**          | Expects the subject to literally be `nil`             | `expect( player.GetAll()[2] ).to.beNil()`                       |
 | **`exist`**          | Expects the subject to not be `nil`                   | `expect( MyProject ).to.exist()`                                |
-| **`beA`**/**`beAn`** | Expects the subject to have the given `type`          | `expect( "test" ).to.beA( "string" )`                           |
+| **`beA`**/**`beAn`**     | Expects the subject to have the given `type`          | `expect( "test" ).to.beA( "string" )`                           |
 | **`succeed`**        | Expects the subject function to run without error     | `expect( func, param ).to.succeed()`                            |
 | **`err`**            | Expects the subject function to throw an error        | `expect( error ).to.err()`                                      |
 | **`errWith`**        | Expects the subject function to throw the given error | `expect( badFunc, param ).to.errWith( "error message" )`        |
-| **`haveBeenCalled`** | Expects the subject Stub have been called             | `expect( myStub ).to.haveBeenCalled()`                          |
+| **`called`**         | Expects the subject Stub have been called             | `expect( myStub ).was.called()`                                 |
 
 <br>
 
 #### Expectation Negation
 You can invert an Expectation by using `.toNot` or `.notTo` in place of your `.to`
+
+#### Was
+You may replace `.to` with `.was` in any expectation.
+`.wasNot` is also valid.
 
 i.e.:
 ```lua

--- a/lua/gluatest/expectations/expect.lua
+++ b/lua/gluatest/expectations/expect.lua
@@ -8,7 +8,10 @@ return function( subject, ... )
     local expect = {
         to = positive,
         notTo = negative,
-        toNot = negative
+        toNot = negative,
+
+        was = positive,
+        wasNot = negative
     }
 
     hook.Run( "GLuaTest_CreateExpect", expect )

--- a/lua/gluatest/expectations/negative.lua
+++ b/lua/gluatest/expectations/negative.lua
@@ -126,11 +126,16 @@ return function( subject, ... )
     -- An important distinction between this and the Positive version:
     -- the Positive expectation lets you specify how many times it
     -- should have been called, but this one does not
-    function expectations.haveBeenCalled()
+    function expectations.called()
         local callCount = subject.callCount
         if callCount > 0 then
             i.expected( "to not have been called, got: %d", callCount )
         end
+    end
+
+    function expectations.haveBeenCalled()
+        GLuaTest.DeprecatedNotice( "to.haveBeenCalled()", "was.called()" )
+        return expectations.called()
     end
 
     return expectations

--- a/lua/gluatest/expectations/positive.lua
+++ b/lua/gluatest/expectations/positive.lua
@@ -118,7 +118,7 @@ return function( subject, ... )
         end
     end
 
-    function expectations.haveBeenCalled( n )
+    function expectations.called( n )
         local callCount = subject.callCount
 
         if n == nil then
@@ -130,6 +130,11 @@ return function( subject, ... )
                 i.expected( "to have been called exactly %d times, got: %d", n, callCount )
             end
         end
+    end
+
+    function expectations.haveBeenCalled( n )
+        GLuaTest.DeprecatedNotice( "to.haveBeenCalled( number )", "was.called( number )" )
+        return expectations.called( n )
     end
 
     -- Soon..

--- a/lua/gluatest/init.lua
+++ b/lua/gluatest/init.lua
@@ -1,6 +1,13 @@
+local RED = Color( 255, 0, 0 )
+
 GLuaTest = {
     -- If, for some reason, you need to run GLuaTest clientside, set this to true
-    RUN_CLIENTSIDE = false
+    RUN_CLIENTSIDE = false,
+
+    DeprecatedNotice = function( old, new )
+        local msg = [[GLuaTest: (DEPRECATION NOTICE) "]] .. old .. [[" is deprecated, use "]] .. new .. [[" instead.]]
+        if SERVER then MsgC( RED, msg .. "\n" ) end
+    end
 }
 
 if GLuaTest.RUN_CLIENTSIDE then


### PR DESCRIPTION
The goal here is to make some expectations "feel" better when writing them out.

e.g.
```lua
expect( func ).to.haveBeenCalled()
```
vs.
```lua
expect( func ).was.called()
```