### PR TITLE
add PlainLogEnd and PlainLogStart

### DIFF
--- a/lua/gluatest/runner/logger.lua
+++ b/lua/gluatest/runner/logger.lua
@@ -304,8 +304,18 @@ function ResultLogger.LogTestsComplete( testGroups, allResults, duration )
     ResultLogger.logSummaryCounts( allResults )
     ResultLogger.logFailureSummary( allResults )
     MsgC( "\n" )
+    ResultLogger.PlainLogEnd()
 end
 
+-- External parsers rely on the output of this function it should not be changed often
+function ResultLogger.PlainLogStart()
+    print( "[GLuaTest]: Test run starting..." )
+end
+
+-- External parsers rely on the output of this function it should not be changed often
+function ResultLogger.PlainLogEnd()
+    print( "[GLuaTest]: Test run complete!" )
+end
 
 hook.Run( "GLuaTest_MakeResultLogger", ResultLogger )
 

--- a/lua/gluatest/runner/runner.lua
+++ b/lua/gluatest/runner/runner.lua
@@ -45,6 +45,7 @@ return function( allTestGroups )
         if success == false then LogTestFailureDetails( result ) end
     end
 
+    ResultLogger.PlainLogStart()
     hook.Run( "GLuaTest_StartedTestRun", allTestGroups )
     local startTime = SysTime()
     local defaultEnv = getfenv( 1 )

--- a/lua/gluatest/runner/runner.lua
+++ b/lua/gluatest/runner/runner.lua
@@ -9,7 +9,7 @@ local LogFileStart = ResultLogger.LogFileStart
 local LogTestResult = ResultLogger.LogTestResult
 local LogTestsComplete = ResultLogger.LogTestsComplete
 local LogTestFailureDetails = ResultLogger.LogTestFailureDetails
-
+local PlainLogStart = ResultLogger.PlainLogStart
 local noop = function() end
 
 local caseID = 0
@@ -45,7 +45,7 @@ return function( allTestGroups )
         if success == false then LogTestFailureDetails( result ) end
     end
 
-    ResultLogger.PlainLogStart()
+    PlainLogStart()
     hook.Run( "GLuaTest_StartedTestRun", allTestGroups )
     local startTime = SysTime()
     local defaultEnv = getfenv( 1 )


### PR DESCRIPTION
Adds non colored logs at start and end of test to allow programs such as a gluatest CLI to filter the gluatest output without parsing colors