### PR TITLE
Switches the GLuaTest server back to base branch

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,7 +8,7 @@ ARG gmodroot=/home/steam/gmodserver
 ARG server=/home/steam/gmodserver/garrysmod
 
 USER steam
-RUN ./steamcmd.sh +force_install_dir $gmodroot +login anonymous +app_update 4020 -beta x86-64 validate +quit
+RUN ./steamcmd.sh +force_install_dir $gmodroot +login anonymous +app_update 4020 validate +quit
 
 # Initial server config
 RUN touch $gmodroot/custom_server.cfg && mkdir -pv $server/data/

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -104,7 +104,7 @@ srcds_args=(
     +mat_dxlevel 1
 )
 
-stdbuf -oL -eL timeout 2m "$gmodroot"/srcds_run_x64 "${srcds_args[@]}"
+stdbuf -oL -eL timeout 2m "$gmodroot"/srcds_run "${srcds_args[@]}"
 status=$?
 
 if [ "$(cat $server/data/gluatest_clean_exit.txt)" = "false" ]; then


### PR DESCRIPTION
It was on x86-64 for testing purposes, but it's clear now that we need to go back to the main branch for our test environment.

In the future, I might look at a way to select `x86-64` in the workflow configs.