### PR TITLE
Support TYPE_ENUM for beA expectation

### DIFF
--- a/lua/gluatest/expectations/negative.lua
+++ b/lua/gluatest/expectations/negative.lua
@@ -1,4 +1,5 @@
 local type = type
+local TypeID = TypeID
 local IsValid = IsValid
 local string_format = string.format
 
@@ -73,20 +74,13 @@ return function( subject, ... )
     end
 
     function expectations.beA( comparison )
-        local class = type( subject )
+        local class = isnumber( comparison ) and TypeID( subject ) or type( subject )
 
         if class == comparison then
             i.expected( "to not be a '%s'", comparison )
         end
     end
-
-    function expectations.beAn( comparison )
-        local class = type( subject )
-
-        if class == comparison then
-            i.expected( "to not be an '%s'", comparison )
-        end
-    end
+    expectations.beAn = expectations.beA
 
     function expectations.succeed()
         local success = pcall( subject, unpack( args ) )

--- a/lua/gluatest/expectations/positive.lua
+++ b/lua/gluatest/expectations/positive.lua
@@ -1,4 +1,5 @@
 local type = type
+local TypeID = TypeID
 local IsValid = IsValid
 local string_format = string.format
 
@@ -75,7 +76,7 @@ return function( subject, ... )
     end
 
     function expectations.beA( comparison )
-        local class = type( subject )
+        local class = isnumber( comparison ) and TypeID( subject ) or type( subject )
 
         if class ~= comparison then
             i.expected( "to be a '%s'", comparison )


### PR DESCRIPTION
This allows `beA` (+ `beAn`) to support [TYPE](https://wiki.facepunch.com/gmod/Enums/TYPE) enum as well as strings.

It also removes useless `beAn` function from the negative expectations, and replaces it with a reference to `beA` mirroring the positive expectations file.