### PR TITLE
Add skip/when case keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -540,7 +540,7 @@ For example, to run your test case only on the `x86-64` branch:
 }
 ```
 
-Skipping is also hando if you just want to disable a test but keep the code:
+Skipping is also handy if you want to disable a test but keep the code:
 ```lua
 {
     name = "Broken test (but I'll definitely fix it some day 100%),

--- a/README.md
+++ b/README.md
@@ -462,8 +462,8 @@ Each Test Case is a table with the following keys:
 | **`async`**      | `bool`            | If your test relies on timers, hooks, or callbacks, it must run asynchronously |  ❌      | `false` |
 | **`timeout`**    | `int`             | How long to wait for your async test before marking it as having timed out     |  ❌      | 60      |
 | **`cleanup`**    | `function`        | The function to run after running your test. Takes a `state` table             |  ❌      |         |
-| **`when`**       | `bool | function` | Only run this test case "when" this field is _(or evaluates to)_ `true`          |  ❌      |         |
-| **`skip`**       | `bool | function` | Skip this test case if this field is _(or evaluates to)_ `true`                  |  ❌      |         |
+| **`when`**       | `bool / function` | Only run this test case "when" this field is _(or evaluates to)_ `true`          |  ❌      |         |
+| **`skip`**       | `bool / function` | Skip this test case if this field is _(or evaluates to)_ `true`                  |  ❌      |         |
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -455,13 +455,15 @@ The Test Group (that is, the table you return from your Test File) can have the 
 ### The Test Case
 Each Test Case is a table with the following keys:
 
-| Key              | Type       | Description                                                                    | Required | Default |
-|------------------|:----------:|--------------------------------------------------------------------------------|:--------:|:-------:|
-| **`name`**       | `string`   | Name of the Test Case (for reference later)                                    |  ✔️     |         |
-| **`func`**       | `function` | The actual test function. Takes a `state` table                                |  ✔️     |         |
-| **`async`**      | `bool`     | If your test relies on timers, hooks, or callbacks, it must run asynchronously |  ❌     | `false` |
-| **`timeout`**    | `int`      | How long to wait for your async test before marking it as having timed out     |  ❌     | 60      |
-| **`cleanup`**    | `function` | The function to run after running your test. Takes a `state` table             |  ❌     |         |
+| Key          | Type              | Description                                                                    | Required | Default |
+|--------------|:-----------------:|--------------------------------------------------------------------------------|:--------:|:-------:|
+| **`name`**       | `string`          | Name of the Test Case (for reference later)                                    |  ✔️       |         |
+| **`func`**       | `function`        | The actual test function. Takes a `state` table                                |  ✔️       |         |
+| **`async`**      | `bool`            | If your test relies on timers, hooks, or callbacks, it must run asynchronously |  ❌      | `false` |
+| **`timeout`**    | `int`             | How long to wait for your async test before marking it as having timed out     |  ❌      | 60      |
+| **`cleanup`**    | `function`        | The function to run after running your test. Takes a `state` table             |  ❌      |         |
+| **`when`**       | `bool | function` | Only run this test case "when" this field is _(or evaluates to)_ `true`          |  ❌      |         |
+| **`skip`**       | `bool | function` | Skip this test case if this field is _(or evaluates to)_ `true`                  |  ❌      |         |
 
 <br>
 
@@ -508,15 +510,46 @@ There are a number of different expectations you can use.
 #### Expectation Negation
 You can invert an Expectation by using `.toNot` or `.notTo` in place of your `.to`
 
-#### Was
-You may replace `.to` with `.was` in any expectation.
-`.wasNot` is also valid.
-
 i.e.:
 ```lua
 expect( ply ).toNot.beInvalid()
 expect( "test" ).notTo.beA( "table" )
 ```
+
+#### Was
+You may replace `.to` with `.was` in any expectation.
+`.wasNot` is also valid.
+
+Primarily this is syntax sugar for the `called` expectation. Technically these two calls are equivalent:
+```lua
+expect( func ).to.called()
+expect( func ).was.called()
+```
+
+#### `when` and `skip`
+These fields can be used to control your test invocation.
+
+For example, to run your test case only on the `x86-64` branch:
+```lua
+{
+    name = "Is valid on x86-64",
+    when = BRANCH == "x86-64",
+    func = function()
+        -- x86-64 specific stuff here
+    end
+}
+```
+
+Skipping is also hando if you just want to disable a test but keep the code:
+```lua
+{
+    name = "Broken test (but I'll definitely fix it some day 100%),
+    skip = true,
+    func = function() error() end
+}
+```
+
+**Note:** `skip` takes precedence over `when`
 
 <br>
 

--- a/lua/gluatest/runner/logger.lua
+++ b/lua/gluatest/runner/logger.lua
@@ -152,18 +152,21 @@ function ResultLogger.getResultCounts( allResults )
     local passed = 0
     local failed = 0
     local empty = 0
+    local skipped = 0
 
     for _, result in ipairs( allResults ) do
         if result.success == true then
             passed = passed + 1
         elseif result.success == false then
             failed = failed + 1
-        else
+        elseif result.empty then
             empty = empty + 1
+        elseif result.skipped then
+            skipped = skipped + 1
         end
     end
 
-    return passed, failed, empty
+    return passed, failed, empty, skipped
 end
 
 
@@ -207,8 +210,10 @@ function ResultLogger.LogTestResult( result, usePrefix )
         plog( colors.green, "PASS " )
     elseif success == false then
         plog( colors.red, "FAIL " )
-    elseif success == nil then
+    elseif result.empty then
         plog( colors.darkgrey, "EMPT " )
+    elseif result.skipped then
+        plog( colors.darkgrey, "SKIP " )
     else
         ErrorNoHaltWithStack( "Improper success type" )
         PrintTable( result )
@@ -267,10 +272,11 @@ function ResultLogger.logSummaryCounts( allResults )
     local green = colors.green
     local darkgrey = colors.darkgrey
 
-    local passed, failed, empty = ResultLogger.getResultCounts( allResults )
+    local passed, failed, empty, skipped = ResultLogger.getResultCounts( allResults )
     ResultLogger.prefixLog( white, "| ", green,    "PASS: ", blue, passed, "\n" )
     ResultLogger.prefixLog( white, "| ", red,      "FAIL: ", blue, failed, "\n" )
     ResultLogger.prefixLog( white, "| ", darkgrey, "EMPT: ", blue, empty,  "\n" )
+    ResultLogger.prefixLog( white, "| ", darkgrey, "SKIP: ", blue, skipped,  "\n" )
 end
 
 


### PR DESCRIPTION
This feature easily allows cases to be skipped, or only ran conditionally. For example, if your behavior is intended (or expected) to be different across JIT versions, you could do:
```lua
return {
    groupName = "isrunning action",
    cases = {
        {
            name = "Is not valid on 32bit versions",
            when = jit.version == "LuaJIT 2.0.4",
            func = function()
                expect( collectgarbage, "isrunning" ).to.errWith( [[bad argument #1 to '?' (invalid option 'isrunning')]] )
            end
        },

        {
            name = "Is valid on x86-64",
            when = jit.version == "LuaJIT 2.1.0-beta3",
            func = function()
                expect( collectgarbage, "isrunning" ).to.succeed()
                expect( collectgarbage( "isrunning" ) ).to.beA( "boolean" )
            end
        },
    }
}
```

This also adds a new classification of output at the end; `SKIP`
![image](https://github.com/CFC-Servers/GLuaTest/assets/7936439/166b4bed-c899-498b-9dee-31750b963c9d)
