### PR TITLE
Refactor group timeouts

### DIFF
--- a/lua/gluatest/runner/runner.lua
+++ b/lua/gluatest/runner/runner.lua
@@ -184,7 +184,6 @@ return function( allTestGroups )
             local cbCount = table.Count( callbacks )
             if cbCount ~= asyncCount then return end
 
-            timer.Remove( "GLuaTest_AsyncWaiter" )
             runNextTestGroup( testGroups )
         end
 

--- a/lua/gluatest/runner/runner.lua
+++ b/lua/gluatest/runner/runner.lua
@@ -194,9 +194,7 @@ return function( allTestGroups )
                 ErrorNoHaltWithStack( "Running an empty Async Cleanup func" )
             end
 
-            -- TODO: Find a better way to handle this function
-            -- It shouldn't take a param like this to modify its behavior
-            case.testComplete = function( shouldCheckComplete )
+            case.testComplete = function()
                 timer.Remove( "GLuaTest_AsyncTimeout_" .. case.id )
                 setfenv( case.func, defaultEnv )
 
@@ -204,9 +202,6 @@ return function( allTestGroups )
                 testGroup.afterEach( case.state )
 
                 asyncCleanup()
-
-                if shouldCheckComplete == false then return end
-
                 checkComplete()
             end
 
@@ -261,33 +256,16 @@ return function( allTestGroups )
                 case.testComplete()
             else
                 -- If the test ran successfully, start the case-specific timeout timer
-                -- (If it's configured)
-                if case.timeout then
-                    timer.Create( "GLuaTest_AsyncTimeout_" .. case.id, case.timeout, 1, function()
-                        setTimedOut( case )
-                        callbacks[case.id] = false
+                local timeout = case.timeout or 60
 
-                        case.testComplete()
-                    end )
-                end
-            end
-
-        end
-
-        timer.Create( "GLuaTest_AsyncWaiter", 60, 1, function()
-            for id, case in pairs( asyncCases ) do
-                if callbacks[id] == nil then
+                timer.Create( "GLuaTest_AsyncTimeout_" .. case.id, timeout, 1, function()
                     setTimedOut( case )
                     callbacks[case.id] = false
 
-                    local shouldCheckComplete = false
-                    case.testComplete( shouldCheckComplete )
-                end
+                    case.testComplete()
+                end )
             end
-
-            -- Should always run the next testGroup
-            checkComplete()
-        end )
+        end
     end
 
     runNextTestGroup( allTestGroups )


### PR DESCRIPTION
The group timeouts were a hacky feature. I probably added it as a band-aid fix to stuck test runs.

However, it also introduced unexpected and arguably undocumented functionality.
When a user reads that async test cases have a default timeout of 60 seconds, they assume that omitting `timeout =` from their test case would simply make that value default to 60.

Instead, there was a per-group timer that would continue to the next test group if it expired. This isn't technically the same behavior, and should be simplified.

With this change, a timer is created for every single case with no group timeout.