### PR TITLE
Fix error stack handling

### DIFF
--- a/lua/gluatest/runner/runner.lua
+++ b/lua/gluatest/runner/runner.lua
@@ -1,5 +1,5 @@
 local Helpers = include( "gluatest/runner/helpers.lua" )
-local FailCallback = Helpers.FailCallback
+local SafeRunFunction = Helpers.SafeRunFunction
 local MakeAsyncEnv = Helpers.MakeAsyncEnv
 local SafeRunWithEnv = Helpers.SafeRunWithEnv
 local CreateCaseState = Helpers.CreateCaseState
@@ -244,7 +244,7 @@ return function( allTestGroups )
             setfenv( testGroup.beforeEach, defaultEnv )
 
             setfenv( case.func, asyncEnv )
-            local success, errInfo = xpcall( case.func, FailCallback, case.state )
+            local success, errInfo = SafeRunFunction( case.func, case.state )
 
             -- If the test failed while calling it
             -- (Async expectation failures handled in asyncEnv.expect)


### PR DESCRIPTION
Fixes #64 

Works exactly the same how it worked before, but now it won't throw an error for not being able to get the stack correctly,

New message is:
```
[GLuaTest]: Test run starting...

[GLuaTest] === Running goobie_sql/sqlite.lua... ===
[GLuaTest] FAIL [love or hate, you gonna eat it]
    File:
       addons/goobie_sql/lua/tests/goobie_sql/sqlite.lua

    Context:
      _____________________________________________________________
     |
  17 | do return {
  18 |     cases = {
  19 |         {
  20 |             name = "love or hate, you gonna eat it",
  21 |             func = function()
  22 |                 ("s"):gsub("s", function() <- Unhandled
     |_____________________________________________________________



[GLuaTest] Test run complete! 🎉
[GLuaTest] Ran 1 tests from 1 test groups in 0.008 seconds
[GLuaTest] | PASS: 0
[GLuaTest] | FAIL: 1
[GLuaTest] | EMPT: 0
[GLuaTest] | SKIP: 0

Test failures:
=== goobie_sql/sqlite.lua ===
FAIL [love or hate, you gonna eat it]


[GLuaTest]: Test run complete!
```