### PR TITLE
Try to handle include errors

### DIFF
--- a/lua/gluatest/init.lua
+++ b/lua/gluatest/init.lua
@@ -53,8 +53,8 @@ end
 --- First checks data_static/gluatest_version.txt (when running in docker)
 --- Then, attempts to read the git commit of the cloned GLuaTest repository
 --- Then, gives up
-local function getGLuaTestVersion()
-end
+--- local function getGLuaTestVersion()
+--- end
 
 --- Loads and runs all tests in the tests/ directory
 GLuaTest.runAllTests = function()

--- a/lua/gluatest/loader.lua
+++ b/lua/gluatest/loader.lua
@@ -62,6 +62,11 @@ function Loader.processFile( dir, fileName, groups )
         }
     end
 
+    if not fileOutput.cases then
+        print( "GLuaTest: File " .. filePath .. " did not have a 'cases' field - ignoring" )
+        return
+    end
+
     local testGroup = fileOutput --[[@as GLuaTest_TestGroup]]
 
     if SERVER and success then Loader.checkSendToClients( filePath, testGroup.cases ) end

--- a/lua/gluatest/loader.lua
+++ b/lua/gluatest/loader.lua
@@ -22,12 +22,12 @@ function Loader.getProjectName( dir )
 end
 
 function Loader.simpleError( reason, filePath )
-     return {
-         reason = string.sub( reason, string.find( reason, ":" ) + 1 ),
-         sourceFile = filePath,
-         lineNumber = -1,
-         locals = {}
-     }
+    return {
+        reason = string.sub( reason, string.find( reason, ":" ) + 1 ),
+        sourceFile = filePath,
+        lineNumber = -1,
+        locals = {}
+    }
  end
 
 --- Given a directory and a file name, try to load the file as a TestGroup and build a RunnableTestGroup from it
@@ -38,19 +38,19 @@ function Loader.processFile( dir, fileName, groups )
     if not string.EndsWith( fileName, ".lua" ) then return end
 
     local filePath = dir .. "/" .. fileName
-    local success, result = pcall( function( filePath )
-        local fileContent = file.Read( filePath, "LUA" )
-        local compiled = CompileString( fileContent, "lua/" .. filePath, false )
- 
+    local success, result = pcall( function( givenFilePath )
+        local fileContent = file.Read( givenFilePath, "LUA" )
+        local compiled = CompileString( fileContent, "lua/" .. givenFilePath, false )
+
         if not isfunction( compiled ) then
-            return Loader.simpleError( compiled, filePath )
+            return Loader.simpleError( compiled, givenFilePath )
         end
- 
+
         return compiled()
     end, filePath )
- 
+
     success = success and istable( result ) and not result.sourceFile
- 
+
     local fileOutput
     if success then
         fileOutput = result

--- a/lua/gluatest/runner/logger.lua
+++ b/lua/gluatest/runner/logger.lua
@@ -108,6 +108,10 @@ function ResultLogger.logCodeContext( errInfo )
         end
     end
 
+    if lineNumber == -1 then
+        MsgC( colors.grey,  "     | ", colors.red, reason, "\n" )
+    end
+
     MsgC( colors.grey, "     |", divider, "\n" )
 end
 

--- a/lua/gluatest/runner/logger.lua
+++ b/lua/gluatest/runner/logger.lua
@@ -96,7 +96,7 @@ function ResultLogger.logCodeContext( errInfo )
 
     for i = 1, lineCount do
         local lineContent = lines[i]
-        local contextLineNumber = lineNumber - (lineCount - i)
+        local contextLineNumber = lineNumber - ( lineCount - i )
         local lineNumStr = tostring( contextLineNumber )
         local onFailingLine = contextLineNumber == lineNumber
 
@@ -204,7 +204,7 @@ function ResultLogger.LogFileStart( testGroup )
     local groupName = testGroup.groupName
     local project = testGroup.project
 
-    local identifier = project .. "/" .. (groupName or fileName)
+    local identifier = project .. "/" .. ( groupName or fileName )
 
     MsgC( "\n" )
     ResultLogger.prefixLog( colors.blue, "=== Running ", identifier, "... ===", "\n" )
@@ -318,7 +318,7 @@ function ResultLogger.logFailureSummary( allResults )
         local groupName = group.groupName
         local project = group.project
 
-        local identifier = project .. "/" .. (groupName or fileName)
+        local identifier = project .. "/" .. ( groupName or fileName )
         MsgC( colors.blue, "=== ", identifier, " ===", "\n" )
 
         for _, failure in ipairs( failures ) do

--- a/lua/gluatest/runner/test_group_runner.lua
+++ b/lua/gluatest/runner/test_group_runner.lua
@@ -79,6 +79,11 @@ function GLuaTest.TestGroupRunner( TestRunner, group )
     --- Run all cases in the test group
     --- @param cb fun(): nil The function to run once the group is complete
     function TGR:Run( cb )
+        if group.includeError ~= nil then
+            self:SetFailed( { name = "Failed to include file" }, group.includeError )
+            return cb()
+        end
+
         local beforeAll = group.beforeAll
         if beforeAll then beforeAll( self.groupState ) end
 

--- a/lua/gluatest/types.lua
+++ b/lua/gluatest/types.lua
@@ -68,6 +68,7 @@ end
 --- @param key any The key to stub
 --- @return GLuaTest_Stub
 function stub( tbl, key )
+    -- _ is used to make the GLuaLinter happy, as else it'll complain that the variables are unused.
     _ = tbl
     _ = key
 end

--- a/lua/gluatest/types.lua
+++ b/lua/gluatest/types.lua
@@ -60,6 +60,7 @@
 --- @param subject any The subject of the expectation
 --- @return GLuaTest_Expect
 function expect( subject, ... )
+    _ = subject
 end
 
 --- Create a stub function
@@ -67,4 +68,6 @@ end
 --- @param key any The key to stub
 --- @return GLuaTest_Stub
 function stub( tbl, key )
+    _ = tbl
+    _ = key
 end

--- a/lua/gluatest/types.lua
+++ b/lua/gluatest/types.lua
@@ -60,7 +60,7 @@
 --- @param subject any The subject of the expectation
 --- @return GLuaTest_Expect
 function expect( subject, ... )
-    _ = subject
+    _ = subject -- _ is used to make the GLuaLinter happy, as else it'll complain that the variables are unused.
 end
 
 --- Create a stub function


### PR DESCRIPTION
This solves #62
I tested it locally using https://github.com/CFC-Servers/gmod_tests & created a error in one of the files

If a test fails to be loaded it's now reported like this:

![image](https://github.com/user-attachments/assets/94d20340-70a4-4b19-bad3-340e3ec3d9d9)

It could probably be further improved by using the OnLuaError hook, as pcall seemingly can't really catch include errors, but this already should do just fine.