### PR TITLE
Allow one to use dev & prerelease, Allow one to specify a artifact to use and some other minor changes

### DIFF
--- a/.github/workflows/run_tests_runnerimprovements.yml
+++ b/.github/workflows/run_tests_runnerimprovements.yml
@@ -67,6 +67,12 @@ on:
         required: false
         description: "An absolute path with custom files to copy to the server directly. Structure should match the contents of `garrysmod/`"
 
+      download-artifact:
+        type: string
+        required: false
+        description: "If specified it will download and setup the given artifact. It has to be a tar file that will be unpacked in the root directory."
+        default: ""
+
 env:
   GLUA_REPO: https://github.com/CFC-Servers/GLuaTest
 
@@ -144,14 +150,21 @@ jobs:
         run: |
           rsync --verbose --archive ${{ inputs.custom-overrides }} $GITHUB_WORKSPACE/garrysmod_override/
 
+      - name: Download artifact
+        if: inputs.download-artifact != ''
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ github.workspace }}/gluatest/docker/_gluatest_artifacts/
+          name: "${{ inputs.download-artifact }}"
+
       - name: Build GLuaTest
         env:
           REQUIREMENTS: "${{ github.workspace }}/project/${{ inputs.requirements }}"
           CUSTOM_SERVER_CONFIG: "${{ github.workspace }}/project/${{ inputs.server-cfg }}"
           PROJECT_DIR: "${{ github.workspace }}/garrysmod_override"
-
         run: |
           cd $GITHUB_WORKSPACE/gluatest/docker
+          mkdir -p _gluatest_artifacts
           docker build --build-arg="GMOD_BRANCH=${{ inputs.branch }}" --build-arg="GLUATEST_REPO=${{ env.GLUA_REPO }}.git" --build-arg="GLUATEST_REF=${{ inputs.gluatest-ref }}" --tag ghcr.io/cfc-servers/gluatest:latest .
 
       - name: Run GLuaTest
@@ -165,7 +178,6 @@ jobs:
           SSH_PRIVATE_KEY: "${{ inputs.ssh-private-key }}"
           GITHUB_TOKEN: "${{ inputs.github-token }}"
           TIMEOUT: "${{ inputs.timeout }}"
-
         run: |
           cd $GITHUB_WORKSPACE/gluatest/docker
           docker compose up --pull never --no-log-prefix --exit-code-from runner

--- a/.github/workflows/run_tests_runnerimprovements.yml
+++ b/.github/workflows/run_tests_runnerimprovements.yml
@@ -167,6 +167,7 @@ jobs:
           TIMEOUT: "${{ inputs.timeout }}"
 
         run: |
+          cd $GITHUB_WORKSPACE/gluatest/docker
           docker compose up --pull never --no-log-prefix --exit-code-from runner
           exitstatus=$?
 

--- a/.github/workflows/run_tests_runnerimprovements.yml
+++ b/.github/workflows/run_tests_runnerimprovements.yml
@@ -53,7 +53,7 @@ on:
       branch:
         type: string
         required: false
-        description: "Which GMod branch to run your tests on. Must be: 'live' or 'x86-64'"
+        description: "Which GMod branch to run your tests on. Must be: 'live', 'prerelease', 'dev' or 'x86-64'"
         default: "live"
 
       gluatest-ref:

--- a/.github/workflows/run_tests_runnerimprovements.yml
+++ b/.github/workflows/run_tests_runnerimprovements.yml
@@ -67,6 +67,9 @@ on:
         required: false
         description: "An absolute path with custom files to copy to the server directly. Structure should match the contents of `garrysmod/`"
 
+env:
+  GLUA_REPO: https://github.com/CFC-Servers/GLuaTest
+
 jobs:
   test:
     name: "Run tests"
@@ -89,7 +92,7 @@ jobs:
         run: |
           cd $GITHUB_WORKSPACE
 
-          git clone --single-branch --branch ${{ inputs.gluatest-ref }} --depth 1 https://github.com/CFC-Servers/GLuaTest.git gluatest
+          git clone --single-branch --branch ${{ inputs.gluatest-ref }} --depth 1 ${{ env.GLUA_REPO }}.git gluatest
 
           git fetch --quiet --tags
           latest="$(git describe --tags `git rev-list --tags --max-count=1`)"
@@ -126,7 +129,7 @@ jobs:
             # The repo is likely an addon
             dest="$GITHUB_WORKSPACE/garrysmod_override/addons/project/"
           else
-            echo "::error title=Unknown project structure!::Please report this: https://github.com/CFC-Servers/GLuaTest/issues"
+            echo "::error title=Unknown project structure!::Please report this: ${{ env.GLUA_REPO }}/issues"
             exit 1
           fi
 
@@ -146,7 +149,7 @@ jobs:
 
         run: |
           cd $GITHUB_WORKSPACE/gluatest/docker
-          docker build --build-arg="GMOD_BRANCH=${{ inputs.branch }}" --build-arg="GLUATEST_REF=${{ inputs.gluatest-ref }}" --tag ghcr.io/cfc-servers/gluatest:latest .
+          docker build --build-arg="GMOD_BRANCH=${{ inputs.branch }}" --build-arg="GLUATEST_REPO=${{ env.GLUA_REPO }}.git" --build-arg="GLUATEST_REF=${{ inputs.gluatest-ref }}" --tag ghcr.io/cfc-servers/gluatest:latest .
 
       - name: Run GLuaTest
         env:

--- a/.github/workflows/run_tests_runnerimprovements.yml
+++ b/.github/workflows/run_tests_runnerimprovements.yml
@@ -94,11 +94,14 @@ jobs:
 
           git clone --single-branch --branch ${{ inputs.gluatest-ref }} --depth 1 ${{ env.GLUA_REPO }}.git gluatest
 
+          cd gluatest
           git fetch --quiet --tags
-          latest="$(git describe --tags `git rev-list --tags --max-count=1`)"
+
+          latest=$(git describe --tags $(git rev-list --tags --max-count=1) 2>/dev/null || echo "0.00")
           echo "Latest Tag: $latest"
           echo "LATEST_TAG=$latest" >> $GITHUB_OUTPUT
 
+          cd ../
           cd $GITHUB_WORKSPACE
 
       - name: Prepare the override directory

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -40,6 +40,14 @@ COPY base_server.cfg $server/cfg/test.cfg
 # Base fixture addon
 COPY testfixture $server/addons/testfixture
 
+# Any additional files
+COPY _gluatest_artifacts/ $gmodroot/
+
+RUN for file in $gmodroot/*.tar.gz; do \
+      tar -xzf "$file" -C "$gmodroot" && \
+      rm -f "$file"; \
+    done
+
 # Make requirements file
 RUN touch $gmodroot/requirements.txt
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,6 +16,12 @@ USER steam
 RUN if [ "$GMOD_BRANCH" = "x86-64" ]; then \
     echo "Downloading x86-64 branch"; \
     ./steamcmd.sh +force_install_dir $gmodroot +login anonymous +app_update 4020 -beta x86-64 validate +quit; \
+elif [ "$GMOD_BRANCH" = "dev" ]; then \
+    echo "Downloading dev branch"; \
+    ./steamcmd.sh +force_install_dir $gmodroot +login anonymous +app_update 4020 -beta dev validate +quit; \
+elif [ "$GMOD_BRANCH" = "prerelease" ]; then \
+    echo "Downloading prerelease branch"; \
+    ./steamcmd.sh +force_install_dir $gmodroot +login anonymous +app_update 4020 -beta prerelease validate +quit; \
 else \
     echo "Downloading live branch"; \
     ./steamcmd.sh +force_install_dir $gmodroot +login anonymous +app_update 4020 validate +quit; \


### PR DESCRIPTION
[+] You can now use `dev` & `prerelease`
[+] You can now specify a artifact to use.
[#] You now have `env.GLUA_REPO` to specify the GLuaTest repo to use, makes it easier for forks to change the workflow.
[#] Fixed a bug where git would fail as it never entered the `gluatest` directory.
[#] Fixed an issue with `git describe` where it would fail if the repo had no tags at all, instead it now falls back to `0.00`.