### PR TITLE
Try to handle crashes

### DIFF
--- a/.github/workflows/run_tests_runnerimprovements.yml
+++ b/.github/workflows/run_tests_runnerimprovements.yml
@@ -180,6 +180,7 @@ jobs:
           TIMEOUT: "${{ inputs.timeout }}"
         run: |
           cd $GITHUB_WORKSPACE/gluatest/docker
+          echo "core" | sudo tee /proc/sys/kernel/core_pattern # RaphaelIT7: Setting up the core pattern here as inside the docker image it's a read-only filesystem
           docker compose up --pull never --no-log-prefix --exit-code-from runner
           exitstatus=$?
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,7 +6,7 @@ ARG GLUATEST_REPO=https://github.com/CFC-Servers/GLuaTest.git
 
 USER root
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt update && apt install -y --no-install-recommends --no-install-suggests git python3-minimal expect rsync openssh-client && apt autoremove
+RUN apt update && apt install -y --no-install-recommends --no-install-suggests git python3-minimal expect rsync openssh-client gdb && apt autoremove
 
 ARG home=/home/steam
 ARG gmodroot=$home/gmodserver
@@ -53,6 +53,9 @@ RUN touch $gmodroot/requirements.txt
 
 # GitHub Server Keys
 RUN ssh-keyscan github.com >> $home/github_known_hosts
+
+# Enable core dumps
+RUN ulimit -c unlimited
 
 # Entrypoint
 COPY entrypoint.sh $gmodroot/entrypoint.sh

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -86,6 +86,8 @@ base_srcds_args=(
     # Test requirements
     -systemtest       # Allows us to exit the game from inside Lua
     -condebug         # Logs everything to console.log
+    -debug            # On crashes generate a debug.log allowing for better debugging.
+    -norestart        # If we crash, do not restart.
 
     # Disabling things we don't need/want
     -nodns            # Disables DNS requests and resolving DNS addresses
@@ -131,6 +133,13 @@ if [ "$GMOD_BRANCH" = "x86-64" ]; then
 else
     echo "Starting 32-bit server"
     unbuffer timeout "$timeout" "$gmodroot"/srcds_run "$srcds_args"
+fi
+
+if [ -f "$gmodroot/debug.log" ]; then
+	cat "$gmodroot/debug.log" # Dump the entire debug log
+
+	echo "::error:: Server crashed! - Failing workflow"
+	exit 1
 fi
 
 status=$?


### PR DESCRIPTION
This will allow for some crash handling, but the main issue I found is that the core files are not generated in the base path, causing the debug.log's to end up empty.

> [!NOTE]
> Currently if the GLuaTest runner crashes it reboots every time and retries until it hits the timeout where it's then completes as succeded.

I would just do `echo "core" > /proc/sys/kernel/core_pattern` but docker complains that it's a read-only filesystem >:(
So I need to figure out how to set the core pattern somehow (if anyone knows how pls help xd).