### PR TITLE
Extent artifact argument & add "additional-setup" input & some fixes

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -156,12 +156,12 @@ jobs:
 
           mkdir --verbose --parents "$dest"
           cp --recursive --verbose $source/* "$dest/"
+          mkdir -p ${{ github.workspace }}/gluatest/docker/_gluatest_artifacts/ # Silently also setup the artifacts dir
 
       - name: Sync custom overrides
         if: ${{ inputs.custom-overrides }}
         run: |
           rsync --verbose --archive ${{ inputs.custom-overrides }} $GITHUB_WORKSPACE/garrysmod_override/
-          mkdir -p ${{ github.workspace }}/gluatest/docker/_gluatest_artifacts/ # Silently also setup the artifacts dir
 
       - name: Download artifact (Github)
         if: inputs.download-artifact != '' && !(startsWith(inputs.download-artifact, 'https://') || startsWith(inputs.download-artifact, 'http://'))

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -184,6 +184,7 @@ jobs:
 
       - name: Pull GLuaTest Runner
         run: |
+          cd $GITHUB_WORKSPACE/gluatest/docker
           if [ ${{ inputs.branch }} = "x86-64" ]; then
             echo "Updating compose file to use x86-64 image"
             # Replace 'cfc-servers/gluatest' with 'cfc-servers/gluatest/64bit'

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -85,8 +85,14 @@ on:
         description: "If specified it execute the given string as a command after everything was set up allowing you to execute additional commands/scripts"
         default: ""
 
+      dockerbuild:
+        type: string
+        required: false
+        description: "If enabled it will build the docker image from scratch"
+        default: "false"
+
 env:
-  GLUA_REPO: https://github.com/CFC-Servers/GLuaTest
+  GLUA_REPO: https://github.com/${{ github.repository }}
 
 jobs:
   test:
@@ -110,9 +116,11 @@ jobs:
         run: |
           cd $GITHUB_WORKSPACE
 
-          git clone --single-branch --branch ${{ inputs.gluatest-ref }} --depth 1 ${{ env.GLUA_REPO }}.git gluatest
+          git clone --single-branch --depth 1 ${{ env.GLUA_REPO }}.git gluatest
 
           cd gluatest
+          git fetch --quiet origin ${{ inputs.gluatest-ref }}
+          git checkout FETCH_HEAD
           git fetch --quiet --tags
 
           latest=$(git describe --tags $(git rev-list --tags --max-count=1) 2>/dev/null || echo "0.00")
@@ -183,6 +191,7 @@ jobs:
           ${{ inputs.additional-setup }}
 
       - name: Pull GLuaTest Runner
+        if: inputs.dockerbuild != 'true'
         run: |
           cd $GITHUB_WORKSPACE/gluatest/docker
           if [ ${{ inputs.branch }} = "x86-64" ]; then
@@ -204,6 +213,21 @@ jobs:
           fi
 
           docker compose pull
+
+      - name: Build GLuaTest
+        if: inputs.dockerbuild == 'true'
+        env:
+          REQUIREMENTS: "${{ github.workspace }}/project/${{ inputs.requirements }}"
+          CUSTOM_SERVER_CONFIG: "${{ github.workspace }}/project/${{ inputs.server-cfg }}"
+          PROJECT_DIR: "${{ github.workspace }}/garrysmod_override"
+          GMOD_ARTIFACT_DIR: "${{ github.workspace }}/gluatest/docker/_gluatest_artifacts"
+        run: |
+          cd $GITHUB_WORKSPACE/gluatest/docker
+          docker build \
+            --build-arg="GMOD_BRANCH=${{ inputs.branch }}" \
+            --build-arg="GLUATEST_REPO=${{ env.GLUA_REPO }}.git" \
+            --build-arg="GLUATEST_REF=${{ inputs.gluatest-ref }}" \
+            --tag ghcr.io/cfc-servers/gluatest:latest .
 
       - name: Run GLuaTest
         env:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -76,7 +76,13 @@ on:
       download-artifact:
         type: string
         required: false
-        description: "If specified it will download and setup the given artifact. It has to be a tar file that will be unpacked in the root directory."
+        description: "If specified it will download and setup the given artifact (can also be given a url to a file). It has to be a tar file that will be unpacked in the root directory."
+        default: ""
+
+      additional-setup:
+        type: string
+        required: false
+        description: "If specified it execute the given string as a command after everything was set up allowing you to execute additional commands/scripts"
         default: ""
 
 env:
@@ -155,13 +161,26 @@ jobs:
         if: ${{ inputs.custom-overrides }}
         run: |
           rsync --verbose --archive ${{ inputs.custom-overrides }} $GITHUB_WORKSPACE/garrysmod_override/
+          mkdir -p ${{ github.workspace }}/gluatest/docker/_gluatest_artifacts/ # Silently also setup the artifacts dir
 
-      - name: Download artifact
-        if: inputs.download-artifact != ''
+      - name: Download artifact (Github)
+        if: inputs.download-artifact != '' && !(startsWith(inputs.download-artifact, 'https://') || startsWith(inputs.download-artifact, 'http://'))
         uses: actions/download-artifact@v4
         with:
           path: ${{ github.workspace }}/gluatest/docker/_gluatest_artifacts/
           name: "${{ inputs.download-artifact }}"
+
+      - name: Download artifact (Http)
+        if: inputs.download-artifact != '' && (startsWith(inputs.download-artifact, 'https://') || startsWith(inputs.download-artifact, 'http://'))
+        run: |
+          cd ${{ github.workspace }}/gluatest/docker/_gluatest_artifacts/
+          wget -O artifact.tar.gz ${{ inputs.download-artifact }} # No matter what, we expect it as a .tar.gz
+
+      - name: Run Additional Setup
+        if: inputs.additional-setup != ''
+        run: |
+          cd ${{ github.workspace }}
+          ${{ inputs.additional-setup }}
 
       - name: Pull GLuaTest Runner
         run: |

--- a/.github/workflows/self_tests.yml
+++ b/.github/workflows/self_tests.yml
@@ -2,10 +2,20 @@ name: GLuaTest (Self Tests)
 
 on:
   pull_request:
+  push:
 
 jobs:
   lint:
-    uses: CFC-Servers/GLuaTest/.github/workflows/run_tests.yml
+    uses: ./.github/workflows/run_tests.yml
     with:
-      github-ref: ${{ github.head_ref }}
+      gluatest-ref: ${{ github.head_ref || github.ref }}
       server-cfg: lua/tests/gluatest/server.cfg
+      dockerbuild: "true"
+    strategy:
+      matrix:
+        branch:
+          - "x86-64"
+          - "dev"
+          - "prerelease"
+          - "main"
+      fail-fast: false

--- a/.github/workflows/self_tests.yml
+++ b/.github/workflows/self_tests.yml
@@ -3,6 +3,8 @@ name: GLuaTest (Self Tests)
 on:
   pull_request:
   push:
+    branches:
+      - 'main'
 
 jobs:
   run_tests:

--- a/.github/workflows/self_tests.yml
+++ b/.github/workflows/self_tests.yml
@@ -8,7 +8,7 @@ jobs:
   lint:
     uses: ./.github/workflows/run_tests.yml
     with:
-      gluatest-ref: ${{ github.head_ref || github.ref }}
+      gluatest-ref: ${{ github.head_ref != null && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.ref }}
       server-cfg: lua/tests/gluatest/server.cfg
       dockerbuild: "true"
     strategy:

--- a/.github/workflows/self_tests.yml
+++ b/.github/workflows/self_tests.yml
@@ -5,7 +5,7 @@ on:
   push:
 
 jobs:
-  lint:
+  run_tests:
     uses: ./.github/workflows/run_tests.yml
     with:
       gluatest-ref: ${{ github.head_ref != null && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.ref }}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -40,14 +40,6 @@ COPY base_server.cfg $server/cfg/test.cfg
 # Base fixture addon
 COPY testfixture $server/addons/testfixture
 
-# Any additional files
-COPY _gluatest_artifacts/ $gmodroot/
-
-RUN for file in $gmodroot/*.tar.gz; do \
-      tar -xzf "$file" -C "$gmodroot" && \
-      rm -f "$file"; \
-    done
-
 # Make requirements file
 RUN touch $gmodroot/requirements.txt
 
@@ -70,7 +62,11 @@ RUN chown --recursive steam:steam \
 USER steam
 ENV GMOD_BRANCH=${GMOD_BRANCH}
 
-RUN git clone --depth 1 --branch $GLUATEST_REF $GLUATEST_REPO $server/addons/gluatest
+RUN git clone --depth 1 $GLUATEST_REPO $server/addons/gluatest && \
+    cd $server/addons/gluatest && \
+    git fetch --quiet origin $GLUATEST_REF && \
+    git checkout FETCH_HEAD
+
 RUN mkdir --parents --verbose $server/addons/gluatest/data_static
 RUN echo "$GLUATEST_REF" > $server/addons/gluatest/data_static/gluatest_version.txt
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -159,7 +159,7 @@ if [ -f "$gmodroot/debug.log" ]; then
 	exit 1
 fi
 
-if [ "$(cat $server/data/gluatest_clean_exit.txt)" = "false" ]; then
+if [ ! -f "$server/data/gluatest_clean_exit.txt" ] || [ "$(cat $server/data/gluatest_clean_exit.txt)" = "false" ]; then
     echo "::warning:: Test runner did not exit cleanly. Test results unavailable!"
     exit 1 # This should never happen normally, GLuaTest probably had an error while executing so we should fail.
 fi

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -15,15 +15,17 @@ rm -rf _tmp_ssh _tmp_https
 
 # Copy the overrides overtop the server files
 echo "Copying serverfiles overrides..."
-rsync --verbose --archive $home/serverfiles_override/ $gmodroot/
+rsync --verbose --archive $home/garrysmod_override/ $server/
 
 # Any additional files
-cp $home/_gluatest_artifacts/_gluatest_artifacts/* $gmodroot/
+if [ -n "$(ls -A $home/_gluatest_artifacts/_gluatest_artifacts/)" ]; then # Only execute if there are any artifacts or else tar will complain
+    cp $home/_gluatest_artifacts/_gluatest_artifacts/* $gmodroot/
 
-for file in $gmodroot/*.tar.gz; do \
-    tar --extract --verbose --ungzip --file="$file" --directory="$gmodroot" && \
-    rm --force --verbose "$file"; \
-done
+    for file in $gmodroot/*.tar.gz; do \
+        tar --extract --verbose --ungzip --file="$file" --directory="$gmodroot" && \
+        rm --force --verbose "$file"; \
+    done
+fi
 
 if [ -f "$gmodroot/custom_requirements.txt" ]; then
     echo "Appending custom requirements"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -145,6 +145,13 @@ else
     unbuffer timeout "$timeout" "$gmodroot"/srcds_run "$srcds_args"
 fi
 
+status=$?
+
+if [ "$status" -ne 0 ]; then
+    echo "::error:: Something went wrong! - Failing workflow"
+    exit "$status"
+fi
+
 if [ -f "$gmodroot/debug.log" ]; then
 	cat "$gmodroot/debug.log" # Dump the entire debug log
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -140,6 +140,12 @@ echo "GMOD_BRANCH: $GMOD_BRANCH"
 if [ "$GMOD_BRANCH" = "x86-64" ]; then
     echo "Starting 64-bit server"
     unbuffer timeout "$timeout" "$gmodroot"/srcds_run_x64 "$srcds_args"
+elif [ "$GMOD_BRANCH" = "prerelease" ]; then
+    echo "Starting 32-bit prerelease server"
+    unbuffer timeout "$timeout" "$gmodroot"/srcds_run "$srcds_args"
+elif [ "$GMOD_BRANCH" = "dev" ]; then
+    echo "Starting 32-bit dev server"
+    unbuffer timeout "$timeout" "$gmodroot"/srcds_run "$srcds_args"
 else
     echo "Starting 32-bit server"
     unbuffer timeout "$timeout" "$gmodroot"/srcds_run "$srcds_args"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -113,6 +113,7 @@ base_srcds_args=(
     -hushasserts      # "Disables a number of asserts in core Source libraries, skipping some error checks and messages"
     -snoforceformat   # Skips sound buffer creation
     -insecure         # Disable VAC
+    -noconclr         # Breaks ::error outputs
 
     # Optimizations
     -collate          # "Skips everything, just merges the reslist from temp folders to the final folder again"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -113,7 +113,6 @@ base_srcds_args=(
     -hushasserts      # "Disables a number of asserts in core Source libraries, skipping some error checks and messages"
     -snoforceformat   # Skips sound buffer creation
     -insecure         # Disable VAC
-    -noconclr         # Breaks ::error outputs
 
     # Optimizations
     -collate          # "Skips everything, just merges the reslist from temp folders to the final folder again"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -152,11 +152,9 @@ if [ -f "$gmodroot/debug.log" ]; then
 	exit 1
 fi
 
-status=$?
-
 if [ "$(cat $server/data/gluatest_clean_exit.txt)" = "false" ]; then
     echo "::warning:: Test runner did not exit cleanly. Test results unavailable!"
-    exit "$status"
+    exit 1 # This should never happen normally, GLuaTest probably had an error while executing so we should fail.
 fi
 
 if [ -s "$server/data/gluatest_failures.json" ]; then

--- a/docker/testfixture/lua/includes/dev_server_test.lua
+++ b/docker/testfixture/lua/includes/dev_server_test.lua
@@ -27,8 +27,8 @@ hook.Add( "GLuaTest_LoggedTestFailure", "TestLog", function( errInfo )
 
     if ghOutput:GetBool() then
         local fi = failInfo
-        local str = "::error file=%s,line=%s::%s"
-        print( string_format( str, fi.sourceFile, fi.lineNumber, fi.reason ) )
+        local str = "\n::error file=%s,line=%s::%s" -- RaphaelIT7: We require the \n at the beginning since print uses colors in the output which would cause Github to not recognize the ::error:: unless it's a new line. (Thx Rubat for suggesting this <3)
+        print( string_format( str, fi.sourceFile, fi.lineNumber, fi.reason ) ) -- ToDo: Switch to MsgC( color_white ) in the next GMod update because of https://github.com/Facepunch/garrysmod-requests/issues/2712
     end
 end )
 

--- a/lua/gluatest/runner/helpers.lua
+++ b/lua/gluatest/runner/helpers.lua
@@ -235,7 +235,7 @@ function Helpers.FailCallback( reason )
 
     return {
         reason = cleanReason,
-        sourceFile = info.short_src,
+        sourceFile = info.short_src ~= "[C]" and info.short_src, -- Inside loggger.lua ->  ResultLogger.LogTestFailureDetails it will fallback to the origin of the case function that failed.
         lineNumber = info.currentline,
         locals = locals
     }

--- a/lua/tests/gluatest/init.lua
+++ b/lua/tests/gluatest/init.lua
@@ -20,7 +20,6 @@ return {
         {
             name = "Convars exist",
             func = function()
-                expect( ConVarExists( "gluatest_use_ansi" ) ).to.beTrue()
                 expect( ConVarExists( "gluatest_enable" ) ).to.beTrue()
             end
         }


### PR DESCRIPTION
[+] Added `additional-setup` input to allow one to execute command/scripts on setup
[#] Fixed entrypoint using `serverfiles_override` instead of `garrysmod_override`
[#] Fixed tar complaining if no artifacts exist
[#] Fail the workflow if GLuaTest failed to exit clearly -> Should only happen if there was some error
[#] Fixed it failing on "Pull GLuaTest Runner" as it didn't enter the right directory