### PR TITLE
Lower default timeout, print err details at the end, fix type errs

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,7 +505,7 @@ Each Test Case is a table with the following keys:
 | **`func`**       | `function`        | The actual test function. Takes a `state` table                                |  ✔️       |         |
 | **`async`**      | `bool`            | If your test relies on timers, hooks, or callbacks, it must run asynchronously |  ❌      | `false` |
 | **`coroutine`**  | `bool`            | This allows your test to use coroutines to control its execution               |  ❌      | `false` |
-| **`timeout`**    | `int`             | How long to wait for your async test before marking it as having timed out     |  ❌      | 60      |
+| **`timeout`**    | `int`             | How long to wait for your async test before marking it as having timed out     |  ❌      | 5       |
 | **`cleanup`**    | `function`        | The function to run after running your test. Takes a `state` table             |  ❌      |         |
 | **`when`**       | `bool / function` | Only run this test case "when" this field is _(or evaluates to)_ `true`          |  ❌      |         |
 | **`skip`**       | `bool / function` | Skip this test case if this field is _(or evaluates to)_ `true`                  |  ❌      |         |

--- a/docker/testfixture/lua/includes/dev_server_test.lua
+++ b/docker/testfixture/lua/includes/dev_server_test.lua
@@ -5,9 +5,8 @@ local string_format = string.format
 
 local failures = {}
 
--- FCVAR_UNREGISTERED = 1
-local unregistered = 1
-local ghOutput = CreateConVar( "gluatest_github_output", "1", unregistered, "", 0, 1 )
+--- @diagnostic disable-next-line: param-type-mismatch
+local ghOutput = CreateConVar( "gluatest_github_output", "1", FCVAR_UNREGISTERED, "", 0, 1 )
 
 -- Quick status command to show the server setup
 RunConsoleCommand( "status" )

--- a/docker/testfixture/lua/includes/dev_server_test.lua
+++ b/docker/testfixture/lua/includes/dev_server_test.lua
@@ -4,7 +4,10 @@ local string_Split = string.Split
 local string_format = string.format
 
 local failures = {}
-local ghOutput = CreateConVar( "gluatest_github_output", "1", FCVAR_UNREGISTERED, "", 0, 1 )
+
+-- FCVAR_UNREGISTERED = 1
+local unregistered = 1
+local ghOutput = CreateConVar( "gluatest_github_output", "1", unregistered, "", 0, 1 )
 
 -- Quick status command to show the server setup
 RunConsoleCommand( "status" )

--- a/lua/gluatest/init.lua
+++ b/lua/gluatest/init.lua
@@ -1,5 +1,11 @@
 local RED = Color( 255, 0, 0 )
 
+-- Fixes some weird LuaLS complaint
+-- FCVAR_PROTECTED = 32
+local protected = 32
+-- FCVAR_ARCHIVE = 128
+local archive = 128
+
 --- @type VersionTools
 local VersionTools = include( "utils/version.lua" )
 
@@ -32,8 +38,8 @@ if GLuaTest.RUN_CLIENTSIDE then
     AddCSLuaFile( "gluatest/runner/msgc_wrapper.lua" )
 end
 
-local shouldRun = CreateConVar( "gluatest_enable", "1", FCVAR_ARCHIVE + FCVAR_PROTECTED, "Should GLuaTest run?" )
-local shouldSelfTest = CreateConVar( "gluatest_selftest_enable", "0", FCVAR_ARCHIVE + FCVAR_PROTECTED, "Should GLuaTest run its own tests?" )
+local shouldRun = CreateConVar( "gluatest_enable", "1", archive + protected, "Should GLuaTest run?" )
+local shouldSelfTest = CreateConVar( "gluatest_selftest_enable", "0", archive + protected, "Should GLuaTest run its own tests?" )
 
 --- @param loader GLuaTest_Loader
 --- @param projectName string
@@ -102,4 +108,4 @@ end )
 
 concommand.Add( "gluatest_run_tests", function()
     GLuaTest.runAllTests()
-end, nil, "Run all tests in the tests/ directory", FCVAR_PROTECTED )
+end, nil, "Run all tests in the tests/ directory", protected )

--- a/lua/gluatest/init.lua
+++ b/lua/gluatest/init.lua
@@ -1,11 +1,5 @@
 local RED = Color( 255, 0, 0 )
 
--- Fixes some weird LuaLS complaint
--- FCVAR_PROTECTED = 32
-local protected = 32
--- FCVAR_ARCHIVE = 128
-local archive = 128
-
 --- @type VersionTools
 local VersionTools = include( "utils/version.lua" )
 
@@ -38,8 +32,10 @@ if GLuaTest.RUN_CLIENTSIDE then
     AddCSLuaFile( "gluatest/runner/msgc_wrapper.lua" )
 end
 
-local shouldRun = CreateConVar( "gluatest_enable", "1", archive + protected, "Should GLuaTest run?" )
-local shouldSelfTest = CreateConVar( "gluatest_selftest_enable", "0", archive + protected, "Should GLuaTest run its own tests?" )
+--- @diagnostic disable-next-line: param-type-mismatch
+local shouldRun = CreateConVar( "gluatest_enable", "1", FCVAR_ARCHIVE + FCVAR_PROTECTED, "Should GLuaTest run?" )
+--- @diagnostic disable-next-line: param-type-mismatch
+local shouldSelfTest = CreateConVar( "gluatest_selftest_enable", "0", FCVAR_ARCHIVE + FCVAR_PROTECTED, "Should GLuaTest run its own tests?" )
 
 --- @param loader GLuaTest_Loader
 --- @param projectName string
@@ -106,6 +102,5 @@ hook.Add( "Tick", "GLuaTest_Runner", function()
     GLuaTest.runAllTests()
 end )
 
-concommand.Add( "gluatest_run_tests", function()
-    GLuaTest.runAllTests()
-end, nil, "Run all tests in the tests/ directory", protected )
+--- @diagnostic disable-next-line: param-type-mismatch
+concommand.Add( "gluatest_run_tests", GLuaTest.runAllTests, nil, "Run all tests in the tests/ directory", FCVAR_PROTECTED )

--- a/lua/gluatest/loader.lua
+++ b/lua/gluatest/loader.lua
@@ -75,6 +75,7 @@ function Loader.processFile( dir, fileName, groups )
 
     if SERVER and success then Loader.checkSendToClients( filePath, testGroup.cases ) end
 
+    --- @type GLuaTest_RunnableTestGroup
     local group = {
         cases = testGroup.cases,
         groupName = testGroup.groupName,
@@ -85,7 +86,9 @@ function Loader.processFile( dir, fileName, groups )
 
         fileName = fileName,
         project = Loader.getProjectName( filePath )
-    } --[[@as GLuaTest_RunnableTestGroup]]
+    }
+
+    hook.Run( "GLuaTest_TestGroupLoaded", group, testGroup )
 
     table.insert( groups, group )
 end

--- a/lua/gluatest/runner/helpers.lua
+++ b/lua/gluatest/runner/helpers.lua
@@ -260,8 +260,8 @@ function Helpers.MakeAsyncEnv( done, fail, onFailedExpectation )
     local asyncEnv = {
         -- We manually catch expectation errors here in case
         -- they're called in an async function
-        expect = function( subject, ... )
-            local built = expect( subject, ... )
+        expect = function( ... )
+            local built = expect( ... )
             local expected = built.to.expected
             local recordedFailure = false
 
@@ -271,8 +271,20 @@ function Helpers.MakeAsyncEnv( done, fail, onFailedExpectation )
             built.to.expected = function( ... )
                 if recordedFailure then return end
 
+                local stack = debug.getinfo( 3, "lnS" )
+                local locals = Helpers.getLocals( 3 )
+
                 local _, errInfo = xpcall( expected, Helpers.FailCallback, ... )
-                onFailedExpectation( errInfo --[[@as GLuaTest_FailCallbackInfo]] )
+                assert( errInfo )
+
+                local final = {
+                    reason = errInfo.reason,
+                    sourceFile = stack.short_src,
+                    lineNumber = stack.currentline,
+                    locals = locals
+                }
+
+                onFailedExpectation( final --[[@as GLuaTest_FailCallbackInfo]] )
 
                 recordedFailure = true
             end

--- a/lua/gluatest/runner/helpers.lua
+++ b/lua/gluatest/runner/helpers.lua
@@ -171,6 +171,7 @@ function Helpers.getLocals( level )
 
     while true do
         local name, value = debug.getlocal( level, i )
+
         if name == nil then break end
         if name ~= "(*temporary)" then
             table.insert( locals, { name, value == nil and "nil" or value } )
@@ -272,7 +273,7 @@ function Helpers.MakeAsyncEnv( done, fail, onFailedExpectation )
                 if recordedFailure then return end
 
                 local stack = debug.getinfo( 3, "lnS" )
-                local locals = Helpers.getLocals( 3 )
+                local locals = Helpers.getLocals( 4 )
 
                 local _, errInfo = xpcall( expected, Helpers.FailCallback, ... )
                 assert( errInfo )

--- a/lua/gluatest/runner/logger.lua
+++ b/lua/gluatest/runner/logger.lua
@@ -322,6 +322,7 @@ function ResultLogger.logFailureSummary( allResults )
 
         for _, failure in ipairs( failures ) do
             ResultLogger.LogTestResult( failure, false )
+            ResultLogger.LogTestFailureDetails( failure )
         end
 
         MsgC( "\n" )

--- a/lua/gluatest/runner/test_case_runner.lua
+++ b/lua/gluatest/runner/test_case_runner.lua
@@ -175,7 +175,7 @@ function GLuaTest.TestCaseRunner( TestGroupRunner, case )
         if isDone then return end
 
         -- If the test ran successfully, start the case-specific timeout timer
-        local timeout = case.timeout or 60
+        local timeout = case.timeout or 5
 
         timer.Create( "GLuaTest_AsyncTimeout_" .. case.id, timeout, 1, function()
             TestGroupRunner:SetTimedOut( case )

--- a/lua/gluatest/types.lua
+++ b/lua/gluatest/types.lua
@@ -62,6 +62,8 @@
 --- @return GLuaTest_Expect
 function expect( subject, ... )
     _ = subject -- _ is used to make the GLuaLinter happy, as else it'll complain that the variables are unused.
+
+    return fake --[[@as GLuaTest_Expect]]
 end
 
 --- Create a stub function
@@ -72,4 +74,6 @@ function stub( tbl, key )
     -- _ is used to make the GLuaLinter happy, as else it'll complain that the variables are unused.
     _ = tbl
     _ = key
+
+    return fake --[[@as GLuaTest_Stub]]
 end

--- a/lua/gluatest/types.lua
+++ b/lua/gluatest/types.lua
@@ -31,6 +31,7 @@
 --- @class GLuaTest_RunnableTestGroup : GLuaTest_TestGroup
 --- @field fileName string The name of the file the test is in
 --- @field project string The name of the project the test is in
+--- @field includeError? GLuaTest_FailCallbackInfo The error that occurred when including the test file
 
 --- @class GLuaTest_UngroupedTestResult
 --- @field case GLuaTest_TestCase The test case

--- a/lua/gluatest/types.lua
+++ b/lua/gluatest/types.lua
@@ -63,7 +63,7 @@
 function expect( subject, ... )
     _ = subject -- _ is used to make the GLuaLinter happy, as else it'll complain that the variables are unused.
 
-    return fake --[[@as GLuaTest_Expect]]
+    return _G.fake --[[@as GLuaTest_Expect]]
 end
 
 --- Create a stub function
@@ -75,5 +75,5 @@ function stub( tbl, key )
     _ = tbl
     _ = key
 
-    return fake --[[@as GLuaTest_Stub]]
+    return _G.fake --[[@as GLuaTest_Stub]]
 end


### PR DESCRIPTION
- Lower default case timeout to 5s
- Print error details when they happen, and also after the test run concludes
- Fix LuaLS type issues
- Added `GLuaTest_TestGroupLoaded`
- Fixed expectations in callbacks in async functions (I think?)