### PR TITLE
Remove deprecated Docker variable

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   runner:
     image: ghcr.io/cfc-servers/gluatest:latest


### PR DESCRIPTION
The Docker workflow complains that this variable is no longer used during the startup sequence, so I'm just removing it per the warning message.

`time="2025-05-05T18:57:30Z" level=warning msg="/home/runner/work/ACF-3/ACF-3/gluatest/docker/docker-compose.yml: the attribute "version" is obsolete, it will be ignored, please remove it to avoid potential confusion"`