### PR TITLE
Don't use ::notice:: since it's pointless

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -167,6 +167,7 @@ if [ -s "$server/data/gluatest_failures.json" ]; then
     echo "::warning:: Test failures detected - Failing workflow"
     exit 1
 else
-    echo "::notice:: No test failures detected"
+    # We don't use ::notice:: since there is no point in adding a annotation as we only succeed if nothing went wrong and in all other cases we fail.
+    echo "No test failures detected"
     exit 0
 fi

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -167,7 +167,6 @@ if [ -s "$server/data/gluatest_failures.json" ]; then
     echo "::warning:: Test failures detected - Failing workflow"
     exit 1
 else
-    # We don't use ::notice:: since there is no point in adding a annotation as we only succeed if nothing went wrong and in all other cases we fail.
     echo "No test failures detected"
     exit 0
 fi

--- a/lua/gluatest/runner/helpers.lua
+++ b/lua/gluatest/runner/helpers.lua
@@ -4,7 +4,7 @@ local Helpers = {
     caseIdPrefix = "case_" .. os.time() .. "_",
 }
 
---- @type GLuaTest_Expect
+--- @type fun(subject: any, ...: any): GLuaTest_Expect
 local expect = include( "gluatest/expectations/expect.lua" )
 
 --- @type GLuaTest_StubMaker


### PR DESCRIPTION
If you have a lot of workflows running in one go, these annotations can quickly stack up like this:
![image](https://github.com/user-attachments/assets/c7f42a49-0fcc-410e-a4fc-9ebdaf3e1747)

Since the workflow only succeeds when everything goes fine, it's pointless to have the ::notice:: add a annotation to the run.