### PR TITLE
Try to fix a warning & to allow one to pass secrets without possibly leaking them

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -112,6 +112,8 @@ on:
     secrets:
       secret-startup-args:
         required: false
+      secret-additional-setup:
+        required: false
 
 jobs:
   test:
@@ -208,10 +210,10 @@ jobs:
           wget -O artifact.tar.gz ${{ inputs.download-artifact }} # No matter what, we expect it as a .tar.gz
 
       - name: Run Additional Setup
-        if: inputs.additional-setup != ''
         run: |
           cd ${{ github.workspace }}
           ${{ inputs.additional-setup }}
+          ${{ secrets.secret-additional-setup }}
 
       - name: Pull GLuaTest Runner
         if: inputs.dockerbuild != 'true'


### PR DESCRIPTION
Currently on startup a secret is shown which should be fixed by this.
(Docker slim probably nuked it, this could maybe also cause #88 ?)
<img width="896" height="69" alt="image" src="https://github.com/user-attachments/assets/6e9b8eb4-0825-4bf3-8437-931ea3c63a3b" />

And additionally, I added the optional secret `secret-startup-args` that people can use to pass startup arguments without leaking stuff, hopefully.
These changes are currently untested, one is by docker slim which is only used by the release builds, making testing more difficult & for the secret I'll have to set up the workflow again before I can test it.