### PR TITLE
Copy inclusion errors to the test group

### DIFF
--- a/lua/gluatest/loader.lua
+++ b/lua/gluatest/loader.lua
@@ -85,7 +85,8 @@ function Loader.processFile( dir, fileName, groups )
         afterEach = testGroup.afterEach,
 
         fileName = fileName,
-        project = Loader.getProjectName( filePath )
+        project = Loader.getProjectName( filePath ),
+        includeError = fileOutput.includeError,
     }
 
     hook.Run( "GLuaTest_TestGroupLoaded", group, testGroup )


### PR DESCRIPTION
Otherwise, we don't have it available when trying to construct the always-failing test case.