### PR TITLE
Keep gmod_audio.so on 32x for bass tests (doesn't exist on 64x)

### DIFF
--- a/.github/actions/build_and_push/action.yml
+++ b/.github/actions/build_and_push/action.yml
@@ -67,6 +67,7 @@ runs:
           --include-bin "/usr/bin/gzip" \
           --include-bin "/home/steam/gmodserver/bin/libbass.so" \
           --include-bin "/home/steam/gmodserver/bin/linux64/libbass.so" \
+          --include-bin "/home/steam/gmodserver/bin/gmod_audio.so" \
           --tag $BASE:$rawVersionTag \
           --tag $BASE:gamebuild-$id
 


### PR DESCRIPTION
I'm like 99% sure that slim is nuking the file, though I haven't checked.
So just to be sure, it's probably better to add this since gmod normally never loads the file / it would otherwise be a good candidate for docker slim to nuke it.