### PR TITLE
Trigger gmod_tests after updating updating the build versions

### DIFF
--- a/.github/workflows/check_for_updates.yml
+++ b/.github/workflows/check_for_updates.yml
@@ -227,3 +227,13 @@ jobs:
           fi
         env:
            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Dispatch gmod_tests # Yes we shouldn't normally depend on this, though it really doesn't hurt.
+        run: |
+          curl -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.GH_API_KEY }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/CFC-Servers/gmod_tests/actions/workflows/branch_tests.yml/dispatches \
+            -d '{"ref":"main","inputs":{"force_run":"false"}}'


### PR DESCRIPTION
Would be good to see if it by itself would go fine already without having a seperate workflow / this would make #93 basically redundant if it proves to be good enouth.